### PR TITLE
Fixing compatibility error in #23

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 click
-rasterio
+rasterio>=0.35.0
 rio-mucho>=0.2.1


### PR DESCRIPTION
This fixes issue #23. Looking through the sources, I noticed that `Resampling.bilinear` was introduced in rasterio 0.35, but I had 0.32 installed. 

Since `rio-pansharpen` did not specify an specific version in its `requirements.txt`, the install did not complain that I had an incompatible version of rasterio, it only failed at runtime.