### PR TITLE
Fix window padding function for changes to API of rasterio-1.0

### DIFF
--- a/rio_pansharpen/utils.py
+++ b/rio_pansharpen/utils.py
@@ -109,9 +109,10 @@ def _simple_mask(data, ndv):
     return alpha
 
 
-def _pad_window(wnd, pad):
+def _pad_window(window, pad):
     """Add padding to windows
     """
+    wnd = window.toranges()
     return (
         (wnd[0][0] - pad, wnd[0][1] + pad),
         (wnd[1][0] - pad, wnd[1][1] + pad))


### PR DESCRIPTION
I tried using rio-pansharpen from the command line recently and ran into an error because the `Window` class no longer supports indexing. I think that class was changed from rasterio-0.36 to 1.0. In any case, this patch changes the window padding function in rio-pansharpen to work with the new rasterio API.