### PR TITLE
The example import does not work on MAC

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,8 @@ and outputs:
 
 ::
 
-    >>> from pansharpen import worker
-    >>> from pansharpen.methods import Brovey
+    >>> from rio_pansharpen import worker
+    >>> from rio_pansharpen.methods import Brovey
     ...
     >>> pansharpened = worker.pansharpen(vis, vis_transform, pan, pan_transform,
                            pan_dtype, r_crs, dst_crs, weight,
@@ -75,8 +75,8 @@ and outputs:
 ------------------------------------------
 ::
 
-    >>> from pansharpen import worker
-    >>> from pansharpen.utils import _calc_windows
+    >>> from rio_pansharpen import worker
+    >>> from rio_pansharpen.utils import _calc_windows
     >>> import riomucho
     ...
     >>> worker.calculate_landsat_pansharpen(src_paths, dst_path, dst_dtype,


### PR DESCRIPTION
Importing from pansharpen did not work for me when installing via pip on a Mac. I had to do what I am proposing in the documentation change (use rio_pansharpen) instead to get it working. Not sure if it's a difference in python versions or a new change that is not reflected on the docs.